### PR TITLE
verify NetFx3 is not already loaded

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -74,8 +74,10 @@ class mssql (
     content => template('mssql/config.ini.erb'),
   }
 
-  dism { 'NetFx3':
-    ensure => present,
+  if !(defined (Class['Dism[NetFx3]'])) {
+    dism { 'NetFx3':
+      ensure => present,
+    }
   }
 
   exec { 'install_mssql2008':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -81,7 +81,7 @@ class mssql (
   }
 
   exec { 'install_mssql2008':
-    command   => "${media}\\setup.exe /Action=Install /IACCEPTSQLSERVERLICENSETERMS /QS /CONFIGURATIONFILE=C:\\sql2008install.ini /SQLSVCPASSWORD=\"${sqlsvcpassword}\" /AGTSVCPASSWORD=\"${agtsvcpassword}\" /ASSVCPASSWORD=\"${assvcpassword}\" /RSSVCPASSWORD=\"${rssvcpassword}\"",
+    command   => "${media}\\setup.exe /Action=Install /IACCEPTSQLSERVERLICENSETERMS /QS /CONFIGURATIONFILE=C:\\sql2008install.ini /SQLSVCPASSWORD=\"${sqlsvcpassword}\" /AGTSVCPASSWORD=\"${agtsvcpassword}\" /ASSVCPASSWORD=\"${assvcpassword}\" /SECURITYMODE=SQL /SAPWD=\"${mssql_sa_pwd}\"  /RSSVCPASSWORD=\"${rssvcpassword}\"",
     cwd       => $media,
     path      => $media,
     logoutput => true,


### PR DESCRIPTION
NetFx3 can be part of any base windows configuration and it is not used in exclusive by this mssql module.
It can be used by any other piece of software, thus, loading this feature need to be optional or check its existence before.